### PR TITLE
feat: scaffold shared CityU Beamer skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,12 +1,16 @@
 # Shared agent skills
 
-Contribute the OpenCode and Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) in **`.agents/skills/cityu-beamer/`**. This is the canonical source for both tools; keep their core instructions and helpers together.
+Contribute the OpenCode and Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) in **`.agents/skills/cityuhk-beamer/`**. This is the canonical source for both tools; keep their core instructions and helpers together.
 
 ## Current scope
 
-[cityu-beamer/SKILL.md](cityu-beamer/SKILL.md) provides an initial, instruction-only entry point using this repository's existing theme, examples, and tools. It requires a complete repository checkout. Automated generation helpers, standalone installation, editable PowerPoint export, and validation in both agent hosts remain follow-up work in issue #2.
+[cityuhk-beamer/SKILL.md](cityuhk-beamer/SKILL.md) provides an initial, instruction-only entry point using this repository's existing theme, examples, and tools. It requires a complete repository checkout. Automated generation helpers, standalone installation, editable PowerPoint export, and validation in both agent hosts remain follow-up work in issue #2.
 
-Both [Codex](https://learn.chatgpt.com/docs/build-skills) and [OpenCode](https://opencode.ai/docs/skills/) document project-local discovery under `.agents/skills/`. Start the agent in this repository and request the `cityu-beamer` skill. Record the host and version when testing discovery or generation; the directory layout alone is not evidence of an end-to-end test.
+Both [Codex](https://learn.chatgpt.com/docs/build-skills) and [OpenCode](https://opencode.ai/docs/skills/) document project-local discovery under `.agents/skills/`. Start the agent in this repository and request the `cityuhk-beamer` skill. Record the host and version when testing discovery or generation; the directory layout alone is not evidence of an end-to-end test.
+
+## Naming
+
+Use **CityUHK** in prose and display names and **cityuhk** in lowercase names. The shared skill name and directory are `cityuhk-beamer`. Follow the repository [naming convention](../../CONTRIBUTING.md#naming) when referencing existing template interfaces.
 
 ## Where to contribute
 
@@ -14,14 +18,14 @@ Paths below are relative to the repository root. Create the optional directories
 
 | Location | Contribution |
 | --- | --- |
-| `.agents/skills/cityu-beamer/SKILL.md` | Shared discovery metadata and concise instructions for the generation workflow. |
-| `.agents/skills/cityu-beamer/references/` (as needed) | Detailed input conventions, layout guidance, and example outlines linked from the skill. |
-| `.agents/skills/cityu-beamer/scripts/` (as needed) | Working helpers used specifically by the skill for generation, compilation, or validation. |
+| `.agents/skills/cityuhk-beamer/SKILL.md` | Shared discovery metadata and concise instructions for the generation workflow. |
+| `.agents/skills/cityuhk-beamer/references/` (as needed) | Detailed input conventions, layout guidance, and example outlines linked from the skill. |
+| `.agents/skills/cityuhk-beamer/scripts/` (as needed) | Working helpers used specifically by the skill for generation, compilation, or validation. |
 | `tests/skills/` (as needed) | Behavioral tests and fixtures for those helpers and their delivered output. |
 | `beamerthemeCityU.sty`, `assets/`, and the root `.tex` examples | The existing template sources; reuse these rather than maintaining another copy inside the skill. |
 | `tools/` | Utilities shared with ordinary template maintenance, such as PDF inspection. |
 
-Keep the skill name and folder name `cityu-beamer` aligned. Resolve repository resources relative to the skill's location, and put generated presentations and scratch files in a fresh directory under `build/` or a user-selected output location. A future standalone package must explicitly address resource bundling and versioning before claiming to work outside this checkout.
+Keep the skill name and folder name `cityuhk-beamer` aligned. Resolve repository resources relative to the skill's location, and put generated presentations and scratch files in a fresh directory under `build/` or a user-selected output location. A future standalone package must explicitly address resource bundling and versioning before claiming to work outside this checkout.
 
 ## Contribution and review conventions
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,16 +1,12 @@
 # Shared agent skills
 
-Contribute the OpenCode and Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) in **`.agents/skills/cityuhk-beamer/`**. This is the canonical source for both tools; keep their core instructions and helpers together.
+Contribute the OpenCode and Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) in **`.agents/skills/cityu-beamer/`**. This is the canonical source for both tools; keep their core instructions and helpers together.
 
 ## Current scope
 
-[cityuhk-beamer/SKILL.md](cityuhk-beamer/SKILL.md) provides an initial, instruction-only entry point using this repository's existing theme, examples, and tools. It requires a complete repository checkout. Automated generation helpers, standalone installation, editable PowerPoint export, and validation in both agent hosts remain follow-up work in issue #2.
+[cityu-beamer/SKILL.md](cityu-beamer/SKILL.md) provides an initial, instruction-only entry point using this repository's existing theme, examples, and tools. It requires a complete repository checkout. Automated generation helpers, standalone installation, editable PowerPoint export, and validation in both agent hosts remain follow-up work in issue #2.
 
-Both [Codex](https://learn.chatgpt.com/docs/build-skills) and [OpenCode](https://opencode.ai/docs/skills/) document project-local discovery under `.agents/skills/`. Start the agent in this repository and request the `cityuhk-beamer` skill. Record the host and version when testing discovery or generation; the directory layout alone is not evidence of an end-to-end test.
-
-## Naming
-
-Use **CityUHK** in prose and display names and **cityuhk** in lowercase names. The shared skill name and directory are `cityuhk-beamer`. Follow the repository [naming convention](../../CONTRIBUTING.md#naming) when referencing existing template interfaces.
+Both [Codex](https://learn.chatgpt.com/docs/build-skills) and [OpenCode](https://opencode.ai/docs/skills/) document project-local discovery under `.agents/skills/`. Start the agent in this repository and request the `cityu-beamer` skill. Record the host and version when testing discovery or generation; the directory layout alone is not evidence of an end-to-end test.
 
 ## Where to contribute
 
@@ -18,14 +14,14 @@ Paths below are relative to the repository root. Create the optional directories
 
 | Location | Contribution |
 | --- | --- |
-| `.agents/skills/cityuhk-beamer/SKILL.md` | Shared discovery metadata and concise instructions for the generation workflow. |
-| `.agents/skills/cityuhk-beamer/references/` (as needed) | Detailed input conventions, layout guidance, and example outlines linked from the skill. |
-| `.agents/skills/cityuhk-beamer/scripts/` (as needed) | Working helpers used specifically by the skill for generation, compilation, or validation. |
+| `.agents/skills/cityu-beamer/SKILL.md` | Shared discovery metadata and concise instructions for the generation workflow. |
+| `.agents/skills/cityu-beamer/references/` (as needed) | Detailed input conventions, layout guidance, and example outlines linked from the skill. |
+| `.agents/skills/cityu-beamer/scripts/` (as needed) | Working helpers used specifically by the skill for generation, compilation, or validation. |
 | `tests/skills/` (as needed) | Behavioral tests and fixtures for those helpers and their delivered output. |
 | `beamerthemeCityU.sty`, `assets/`, and the root `.tex` examples | The existing template sources; reuse these rather than maintaining another copy inside the skill. |
 | `tools/` | Utilities shared with ordinary template maintenance, such as PDF inspection. |
 
-Keep the skill name and folder name `cityuhk-beamer` aligned. Resolve repository resources relative to the skill's location, and put generated presentations and scratch files in a fresh directory under `build/` or a user-selected output location. A future standalone package must explicitly address resource bundling and versioning before claiming to work outside this checkout.
+Keep the skill name and folder name `cityu-beamer` aligned. Resolve repository resources relative to the skill's location, and put generated presentations and scratch files in a fresh directory under `build/` or a user-selected output location. A future standalone package must explicitly address resource bundling and versioning before claiming to work outside this checkout.
 
 ## Contribution and review conventions
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,34 @@
+# Shared agent skills
+
+Contribute the OpenCode and Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) in **`.agents/skills/cityu-beamer/`**. This is the canonical source for both tools; keep their core instructions and helpers together.
+
+## Current scope
+
+[cityu-beamer/SKILL.md](cityu-beamer/SKILL.md) provides an initial, instruction-only entry point using this repository's existing theme, examples, and tools. It requires a complete repository checkout. Automated generation helpers, standalone installation, editable PowerPoint export, and validation in both agent hosts remain follow-up work in issue #2.
+
+Both [Codex](https://learn.chatgpt.com/docs/build-skills) and [OpenCode](https://opencode.ai/docs/skills/) document project-local discovery under `.agents/skills/`. Start the agent in this repository and request the `cityu-beamer` skill. Record the host and version when testing discovery or generation; the directory layout alone is not evidence of an end-to-end test.
+
+## Where to contribute
+
+Paths below are relative to the repository root. Create the optional directories only when adding their first working resource.
+
+| Location | Contribution |
+| --- | --- |
+| `.agents/skills/cityu-beamer/SKILL.md` | Shared discovery metadata and concise instructions for the generation workflow. |
+| `.agents/skills/cityu-beamer/references/` (as needed) | Detailed input conventions, layout guidance, and example outlines linked from the skill. |
+| `.agents/skills/cityu-beamer/scripts/` (as needed) | Working helpers used specifically by the skill for generation, compilation, or validation. |
+| `tests/skills/` (as needed) | Behavioral tests and fixtures for those helpers and their delivered output. |
+| `beamerthemeCityU.sty`, `assets/`, and the root `.tex` examples | The existing template sources; reuse these rather than maintaining another copy inside the skill. |
+| `tools/` | Utilities shared with ordinary template maintenance, such as PDF inspection. |
+
+Keep the skill name and folder name `cityu-beamer` aligned. Resolve repository resources relative to the skill's location, and put generated presentations and scratch files in a fresh directory under `build/` or a user-selected output location. A future standalone package must explicitly address resource bundling and versioning before claiming to work outside this checkout.
+
+## Contribution and review conventions
+
+- Keep shared instructions in English. Maintain the repository's paired English and Chinese user documentation when adding public usage or installation steps.
+- Keep `SKILL.md` concise; link detailed references and executable helpers when they are introduced. Add complete resources rather than empty placeholder directories.
+- Link incremental PRs with `Related to #2`; reserve closing keywords for a change that completes the agreed issue scope.
+- Follow [CONTRIBUTING.md](../../CONTRIBUTING.md) and the applicable checks in [docs/VALIDATION.md](../../docs/VALIDATION.md). For new helpers, validate their observable behavior and include the commands and results in the PR.
+- Report compilation, visual inspection, and agent-host checks separately. Do not describe PDF output as editable `.pptx` output.
+
+The Overleaf archive uses an explicit file list in `tools/package.py`; these repository-only skill files are not part of that archive. Resource reuse and any future distribution must preserve the existing [LICENSE](../../LICENSE) and [NOTICE.md](../../NOTICE.md) boundaries.

--- a/.agents/skills/cityu-beamer/SKILL.md
+++ b/.agents/skills/cityu-beamer/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cityu-beamer
+description: Create CityU Beamer PDF presentations and editable LaTeX source from an outline in this repository. Use for English, Chinese, or bilingual slides based on the existing CityU theme.
+---
+
+# CityU Beamer
+
+Use the existing CityU theme to turn an outline into a presentation. This initial instruction-only skill requires the complete repository checkout; standalone packaging and automated helpers are still being developed in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
+
+## Locate the template
+
+Resolve paths relative to this skill directory: the repository root is `../../..`. Read [the usage guide](../../../docs/USAGE.md) for the supported setup and theme commands. Start from [minimal.tex](../../../minimal.tex); consult [example-zh.tex](../../../example-zh.tex) when Chinese text is needed and [main.tex](../../../main.tex) for richer layouts.
+
+## Prepare the presentation
+
+- Use the supplied outline and optional metadata, language, slide count, duration, and source materials. An outline alone is enough for a draft; leave missing author details blank and mark missing evidence or citations for the user to supply.
+- Create a fresh presentation directory under the repository's `build/` directory, or use the user's requested output location. Keep generated work separate from the original examples and avoid replacing existing user files.
+- Place the generated `main.tex`, `beamerthemeCityU.sty`, `latexmkrc`, and the complete `assets/` directory together in that presentation directory. Reuse the repository resources and preserve the existing artwork.
+- Preserve XeLaTeX, 16:9, 11 pt, and the portable TeX Live fonts. For Chinese text, pass `no-math` to fontspec before loading ctex, following the Chinese example's preamble.
+- Use the theme's title, section, content, and closing pages. The title and closing helpers create complete frames; do not nest them inside a `frame`. Automatic section dividers are enabled by default.
+- Split dense content into additional frames and keep images within the available column width, clear of the logo and footer. Replace example content with the user's material; do not treat sample research data as real evidence.
+
+## Compile and inspect
+
+Check that `latexmk`, XeLaTeX, and the dependencies in the usage guide are available. Run from the generated presentation directory:
+
+```sh
+latexmk -xelatex -latexoption=-no-shell-escape -interaction=nonstopmode -halt-on-error -file-line-error -outdir=build main.tex
+```
+
+Use the log to identify compilation errors, missing glyphs, unresolved references, and overflowing content. If dependencies are unavailable or compilation cannot be repaired, preserve the source and report the specific blocker instead of claiming a finished PDF.
+
+For rendered previews, use `tools/inspect_pdf.py` from the repository as documented in [the PDF inspection guide](../../../docs/VALIDATION.md#pdf-checks-and-visual-review). Inspect the generated slides for clipping, overlap, and unreadable content. The guide's `check_examples.py` checks fixed repository fixtures, not arbitrary generated presentations.
+
+Deliver the PDF when compilation succeeds, editable source with its required resources, and available previews. State which checks were actually completed. This workflow produces PDF and LaTeX; if the user requires editable `.pptx`, explain that this output needs a separate implementation rather than silently substituting a PDF or slide screenshots.

--- a/.agents/skills/cityu-beamer/SKILL.md
+++ b/.agents/skills/cityu-beamer/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: cityuhk-beamer
-description: Create CityUHK Beamer PDF presentations and editable LaTeX source from an outline in this repository. Use for English, Chinese, or bilingual slides based on the existing CityUHK theme.
+name: cityu-beamer
+description: Create CityU Beamer PDF presentations and editable LaTeX source from an outline in this repository. Use for English, Chinese, or bilingual slides based on the existing CityU theme.
 ---
 
-# CityUHK Beamer
+# CityU Beamer
 
-Use the existing CityUHK theme to turn an outline into a presentation. This initial instruction-only skill requires the complete repository checkout; standalone packaging and automated helpers are still being developed in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
+Use the existing CityU theme to turn an outline into a presentation. This initial instruction-only skill requires the complete repository checkout; standalone packaging and automated helpers are still being developed in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
 
 ## Locate the template
 
@@ -13,7 +13,6 @@ Resolve paths relative to this skill directory: the repository root is `../../..
 
 ## Prepare the presentation
 
-- Use `CityUHK` as the university abbreviation in presentation text and `cityuhk` in new lowercase identifiers and filenames. Keep references to existing template files and LaTeX commands exact.
 - Use the supplied outline and optional metadata, language, slide count, duration, and source materials. An outline alone is enough for a draft; leave missing author details blank and mark missing evidence or citations for the user to supply.
 - Create a fresh presentation directory under the repository's `build/` directory, or use the user's requested output location. Keep generated work separate from the original examples and avoid replacing existing user files.
 - Place the generated `main.tex`, `beamerthemeCityU.sty`, `latexmkrc`, and the complete `assets/` directory together in that presentation directory. Reuse the repository resources and preserve the existing artwork.

--- a/.agents/skills/cityuhk-beamer/SKILL.md
+++ b/.agents/skills/cityuhk-beamer/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: cityu-beamer
-description: Create CityU Beamer PDF presentations and editable LaTeX source from an outline in this repository. Use for English, Chinese, or bilingual slides based on the existing CityU theme.
+name: cityuhk-beamer
+description: Create CityUHK Beamer PDF presentations and editable LaTeX source from an outline in this repository. Use for English, Chinese, or bilingual slides based on the existing CityUHK theme.
 ---
 
-# CityU Beamer
+# CityUHK Beamer
 
-Use the existing CityU theme to turn an outline into a presentation. This initial instruction-only skill requires the complete repository checkout; standalone packaging and automated helpers are still being developed in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
+Use the existing CityUHK theme to turn an outline into a presentation. This initial instruction-only skill requires the complete repository checkout; standalone packaging and automated helpers are still being developed in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
 
 ## Locate the template
 
@@ -13,6 +13,7 @@ Resolve paths relative to this skill directory: the repository root is `../../..
 
 ## Prepare the presentation
 
+- Use `CityUHK` as the university abbreviation in presentation text and `cityuhk` in new lowercase identifiers and filenames. Keep references to existing template files and LaTeX commands exact.
 - Use the supplied outline and optional metadata, language, slide count, duration, and source materials. An outline alone is enough for a draft; leave missing author details blank and mark missing evidence or citations for the user to supply.
 - Create a fresh presentation directory under the repository's `build/` directory, or use the user's requested output location. Keep generated work separate from the original examples and avoid replacing existing user files.
 - Place the generated `main.tex`, `beamerthemeCityU.sty`, `latexmkrc`, and the complete `assets/` directory together in that presentation directory. Reuse the repository resources and preserve the existing artwork.

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,9 @@ __pycache__/
 !.env.example
 /.idea/
 /.vscode/
-/.agents/
+# Share agent skills while keeping other local agent configuration private.
+/.agents/*
+!/.agents/skills/
 /.codex/
 *.swp
 *~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ Include the compiler and TeX Live versions, operating system or Overleaf setting
 4. Update the corresponding English and Chinese user documents when a public interface changes.
 5. Do not commit `build/`, `dist/`, scratch exports, original PPTs, local environments, or private data. The curated PNGs and example PDFs listed in `previews/README.md` are documentation and should be refreshed with relevant visual changes.
 
+## Agent skill contributions
+
+The shared OpenCode/Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) lives in [`.agents/skills/cityu-beamer/`](.agents/skills/cityu-beamer/SKILL.md). Start with the [skill contribution guide](.agents/skills/README.md) for the directory contract, current scope, and review expectations.
+
+Contribute shared instructions and skill-specific helpers there. Reuse the root theme and artwork; keep general template utilities in `tools/` and add behavioral tests for new skill helpers under `tests/skills/` when needed. Link incremental PRs to issue #2 without closing it until its agreed scope is complete.
+
 ## Documentation language
 
 Maintain complete English and Chinese versions of the repository READMEs, `docs/USAGE.md` / `docs/USAGE.zh.md`, and `overleaf/README.md` / `overleaf/README.zh.md`. Keep corresponding instructions and options aligned; examples and previews may use their own language.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,15 @@ Include the compiler and TeX Live versions, operating system or Overleaf setting
 4. Update the corresponding English and Chinese user documents when a public interface changes.
 5. Do not commit `build/`, `dist/`, scratch exports, original PPTs, local environments, or private data. The curated PNGs and example PDFs listed in `previews/README.md` are documentation and should be refreshed with relevant visual changes.
 
+## Naming
+
+Use **CityUHK** as the university abbreviation in prose and display names, and **cityuhk** in new lowercase identifiers, skill names, and directory names. For example, the shared skill is named `cityuhk-beamer` and displayed as "CityUHK Beamer".
+
+References to existing repository URLs, filenames, and LaTeX commands must retain their actual spelling until those interfaces are migrated together. This includes the repository URL, `beamerthemeCityU.sty`, `\usetheme{CityU}`, and the `\cityu...` commands.
+
 ## Agent skill contributions
 
-The shared OpenCode/Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) lives in [`.agents/skills/cityu-beamer/`](.agents/skills/cityu-beamer/SKILL.md). Start with the [skill contribution guide](.agents/skills/README.md) for the directory contract, current scope, and review expectations.
+The shared OpenCode/Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) lives in [`.agents/skills/cityuhk-beamer/`](.agents/skills/cityuhk-beamer/SKILL.md). Start with the [skill contribution guide](.agents/skills/README.md) for the directory contract, current scope, and review expectations.
 
 Contribute shared instructions and skill-specific helpers there. Reuse the root theme and artwork; keep general template utilities in `tools/` and add behavioral tests for new skill helpers under `tests/skills/` when needed. Link incremental PRs to issue #2 without closing it until its agreed scope is complete.
 
@@ -46,4 +52,4 @@ Changes to release contents must update the explicit source-to-archive mapping i
 
 ## Contribution licensing
 
-By submitting original code or documentation for inclusion, you agree to license those contributions under the project's [MIT License](LICENSE). Do not submit third-party content unless you can document permission to include and redistribute it. CityU artwork is separately governed by [NOTICE.md](NOTICE.md); the code license does not cover it. You retain ownership of your contributions.
+By submitting original code or documentation for inclusion, you agree to license those contributions under the project's [MIT License](LICENSE). Do not submit third-party content unless you can document permission to include and redistribute it. CityUHK artwork is separately governed by [NOTICE.md](NOTICE.md); the code license does not cover it. You retain ownership of your contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,9 @@ Include the compiler and TeX Live versions, operating system or Overleaf setting
 4. Update the corresponding English and Chinese user documents when a public interface changes.
 5. Do not commit `build/`, `dist/`, scratch exports, original PPTs, local environments, or private data. The curated PNGs and example PDFs listed in `previews/README.md` are documentation and should be refreshed with relevant visual changes.
 
-## Naming
-
-Use **CityUHK** as the university abbreviation in prose and display names, and **cityuhk** in new lowercase identifiers, skill names, and directory names. For example, the shared skill is named `cityuhk-beamer` and displayed as "CityUHK Beamer".
-
-References to existing repository URLs, filenames, and LaTeX commands must retain their actual spelling until those interfaces are migrated together. This includes the repository URL, `beamerthemeCityU.sty`, `\usetheme{CityU}`, and the `\cityu...` commands.
-
 ## Agent skill contributions
 
-The shared OpenCode/Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) lives in [`.agents/skills/cityuhk-beamer/`](.agents/skills/cityuhk-beamer/SKILL.md). Start with the [skill contribution guide](.agents/skills/README.md) for the directory contract, current scope, and review expectations.
+The shared OpenCode/Codex workflow for [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) lives in [`.agents/skills/cityu-beamer/`](.agents/skills/cityu-beamer/SKILL.md). Start with the [skill contribution guide](.agents/skills/README.md) for the directory contract, current scope, and review expectations.
 
 Contribute shared instructions and skill-specific helpers there. Reuse the root theme and artwork; keep general template utilities in `tools/` and add behavioral tests for new skill helpers under `tests/skills/` when needed. Link incremental PRs to issue #2 without closing it until its agreed scope is complete.
 
@@ -52,4 +46,4 @@ Changes to release contents must update the explicit source-to-archive mapping i
 
 ## Contribution licensing
 
-By submitting original code or documentation for inclusion, you agree to license those contributions under the project's [MIT License](LICENSE). Do not submit third-party content unless you can document permission to include and redistribute it. CityUHK artwork is separately governed by [NOTICE.md](NOTICE.md); the code license does not cover it. You retain ownership of your contributions.
+By submitting original code or documentation for inclusion, you agree to license those contributions under the project's [MIT License](LICENSE). Do not submit third-party content unless you can document permission to include and redistribute it. CityU artwork is separately governed by [NOTICE.md](NOTICE.md); the code license does not cover it. You retain ownership of your contributions.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Cover, divider, and closing helper pages are excluded from the frame counter. To
 \usetheme[sectionpages=false,footer=false]{CityU}
 ```
 
+## Agent skill development
+
+An initial repository-local [CityU Beamer skill](.agents/skills/cityu-beamer/SKILL.md) provides shared instructions for OpenCode and Codex using the existing template. It currently requires this checkout and targets PDF plus LaTeX source; automated helpers, standalone installation, and validation in both tools are follow-up work in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
+
+Contribute in `.agents/skills/cityu-beamer/`; see the [skill contribution guide](.agents/skills/README.md) (English) for the directory conventions.
+
 ## Documentation
 
 - Usage and customisation: [English](docs/USAGE.md) · [简体中文](docs/USAGE.zh.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CityU Beamer
+# CityUHK Beamer
 
 [English](README.md) · [简体中文](README.zh.md)
 
@@ -75,9 +75,9 @@ Cover, divider, and closing helper pages are excluded from the frame counter. To
 
 ## Agent skill development
 
-An initial repository-local [CityU Beamer skill](.agents/skills/cityu-beamer/SKILL.md) provides shared instructions for OpenCode and Codex using the existing template. It currently requires this checkout and targets PDF plus LaTeX source; automated helpers, standalone installation, and validation in both tools are follow-up work in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
+An initial repository-local [CityUHK Beamer skill](.agents/skills/cityuhk-beamer/SKILL.md) provides shared instructions for OpenCode and Codex using the existing template. It currently requires this checkout and targets PDF plus LaTeX source; automated helpers, standalone installation, and validation in both tools are follow-up work in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
 
-Contribute in `.agents/skills/cityu-beamer/`; see the [skill contribution guide](.agents/skills/README.md) (English) for the directory conventions.
+Contribute in `.agents/skills/cityuhk-beamer/`; see the [skill contribution guide](.agents/skills/README.md) (English) for the directory conventions.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ Issues and pull requests are welcome in English or Chinese. User documentation i
 
 ## License
 
-Original theme code, examples, tools, configuration, and documentation use the [MIT License](LICENSE). CityU artwork, including artwork in the previews, is excluded. See [NOTICE.md](NOTICE.md) for provenance and rights; public redistribution permission for the branding has not been established by this project.
+Original theme code, examples, tools, configuration, and documentation use the [MIT License](LICENSE). CityUHK artwork, including artwork in the previews, is excluded. See [NOTICE.md](NOTICE.md) for provenance and rights; public redistribution permission for the branding has not been established by this project.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CityUHK Beamer
+# CityU Beamer
 
 [English](README.md) · [简体中文](README.zh.md)
 
@@ -75,9 +75,9 @@ Cover, divider, and closing helper pages are excluded from the frame counter. To
 
 ## Agent skill development
 
-An initial repository-local [CityUHK Beamer skill](.agents/skills/cityuhk-beamer/SKILL.md) provides shared instructions for OpenCode and Codex using the existing template. It currently requires this checkout and targets PDF plus LaTeX source; automated helpers, standalone installation, and validation in both tools are follow-up work in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
+An initial repository-local [CityU Beamer skill](.agents/skills/cityu-beamer/SKILL.md) provides shared instructions for OpenCode and Codex using the existing template. It currently requires this checkout and targets PDF plus LaTeX source; automated helpers, standalone installation, and validation in both tools are follow-up work in [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2).
 
-Contribute in `.agents/skills/cityuhk-beamer/`; see the [skill contribution guide](.agents/skills/README.md) (English) for the directory conventions.
+Contribute in `.agents/skills/cityu-beamer/`; see the [skill contribution guide](.agents/skills/README.md) (English) for the directory conventions.
 
 ## Documentation
 
@@ -92,7 +92,7 @@ Issues and pull requests are welcome in English or Chinese. User documentation i
 
 ## License
 
-Original theme code, examples, tools, configuration, and documentation use the [MIT License](LICENSE). CityUHK artwork, including artwork in the previews, is excluded. See [NOTICE.md](NOTICE.md) for provenance and rights; public redistribution permission for the branding has not been established by this project.
+Original theme code, examples, tools, configuration, and documentation use the [MIT License](LICENSE). CityU artwork, including artwork in the previews, is excluded. See [NOTICE.md](NOTICE.md) for provenance and rights; public redistribution permission for the branding has not been established by this project.
 
 ## Acknowledgments
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-# CityUHK Beamer
+# CityU Beamer
 
 [English](README.md) · [简体中文](README.zh.md)
 
@@ -77,9 +77,9 @@ latexmk -xelatex -outdir=build example-zh.tex
 
 ## Agent Skill 开发
 
-仓库内的初版 [CityUHK Beamer skill](.agents/skills/cityuhk-beamer/SKILL.md) 为 OpenCode 和 Codex 提供基于现有模板的共享指引。目前需要完整仓库，输出目标为 PDF 与 LaTeX 源码；自动化脚本、独立安装及两种工具中的验证将在 [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) 中继续推进。
+仓库内的初版 [CityU Beamer skill](.agents/skills/cityu-beamer/SKILL.md) 为 OpenCode 和 Codex 提供基于现有模板的共享指引。目前需要完整仓库，输出目标为 PDF 与 LaTeX 源码；自动化脚本、独立安装及两种工具中的验证将在 [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) 中继续推进。
 
-请在 `.agents/skills/cityuhk-beamer/` 中贡献，目录约定见 [skill 贡献指南](.agents/skills/README.md)（英文）。
+请在 `.agents/skills/cityu-beamer/` 中贡献，目录约定见 [skill 贡献指南](.agents/skills/README.md)（英文）。
 
 ## 文档
 
@@ -94,7 +94,7 @@ latexmk -xelatex -outdir=build example-zh.tex
 
 ## 许可
 
-原创主题代码、示例、工具、配置与文档采用 [MIT 许可](LICENSE)。CityUHK 品牌素材及预览中使用的这些素材不在其中，来源与权利边界见 [NOTICE.md](NOTICE.md)。本项目尚未确立公开再分发品牌素材的权限。
+原创主题代码、示例、工具、配置与文档采用 [MIT 许可](LICENSE)。CityU 品牌素材及预览中使用的这些素材不在其中，来源与权利边界见 [NOTICE.md](NOTICE.md)。本项目尚未确立公开再分发品牌素材的权限。
 
 ## 致谢
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -75,6 +75,12 @@ latexmk -xelatex -outdir=build example-zh.tex
 \usetheme[sectionpages=false,footer=false]{CityU}
 ```
 
+## Agent Skill 开发
+
+仓库内的初版 [CityU Beamer skill](.agents/skills/cityu-beamer/SKILL.md) 为 OpenCode 和 Codex 提供基于现有模板的共享指引。目前需要完整仓库，输出目标为 PDF 与 LaTeX 源码；自动化脚本、独立安装及两种工具中的验证将在 [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) 中继续推进。
+
+请在 `.agents/skills/cityu-beamer/` 中贡献，目录约定见 [skill 贡献指南](.agents/skills/README.md)（英文）。
+
 ## 文档
 
 - 详细用法与自定义接口：[简体中文](docs/USAGE.zh.md) · [English](docs/USAGE.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-# CityU Beamer
+# CityUHK Beamer
 
 [English](README.md) · [简体中文](README.zh.md)
 
@@ -77,9 +77,9 @@ latexmk -xelatex -outdir=build example-zh.tex
 
 ## Agent Skill 开发
 
-仓库内的初版 [CityU Beamer skill](.agents/skills/cityu-beamer/SKILL.md) 为 OpenCode 和 Codex 提供基于现有模板的共享指引。目前需要完整仓库，输出目标为 PDF 与 LaTeX 源码；自动化脚本、独立安装及两种工具中的验证将在 [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) 中继续推进。
+仓库内的初版 [CityUHK Beamer skill](.agents/skills/cityuhk-beamer/SKILL.md) 为 OpenCode 和 Codex 提供基于现有模板的共享指引。目前需要完整仓库，输出目标为 PDF 与 LaTeX 源码；自动化脚本、独立安装及两种工具中的验证将在 [issue #2](https://github.com/inscripoem/cityu-beamer/issues/2) 中继续推进。
 
-请在 `.agents/skills/cityu-beamer/` 中贡献，目录约定见 [skill 贡献指南](.agents/skills/README.md)（英文）。
+请在 `.agents/skills/cityuhk-beamer/` 中贡献，目录约定见 [skill 贡献指南](.agents/skills/README.md)（英文）。
 
 ## 文档
 
@@ -94,7 +94,7 @@ latexmk -xelatex -outdir=build example-zh.tex
 
 ## 许可
 
-原创主题代码、示例、工具、配置与文档采用 [MIT 许可](LICENSE)。CityU 品牌素材及预览中使用的这些素材不在其中，来源与权利边界见 [NOTICE.md](NOTICE.md)。本项目尚未确立公开再分发品牌素材的权限。
+原创主题代码、示例、工具、配置与文档采用 [MIT 许可](LICENSE)。CityUHK 品牌素材及预览中使用的这些素材不在其中，来源与权利边界见 [NOTICE.md](NOTICE.md)。本项目尚未确立公开再分发品牌素材的权限。
 
 ## 致谢
 


### PR DESCRIPTION
The repository currently ignores all of `.agents/`, leaving no versioned home for the OpenCode/Codex workflow proposed in #2. This PR establishes `.agents/skills/cityu-beamer/` as the shared contribution location and adds an initial instruction-only `SKILL.md` that uses the existing theme, examples, and inspection tools.

The contribution guide defines where future references, skill-specific helpers, behavioral tests, and shared template utilities belong. The English and Chinese READMEs link to it, and `.gitignore` now permits shared skills while continuing to ignore other local agent configuration.

Related to #2. This is the first incremental contribution: automated generation helpers, standalone installation, editable PowerPoint output, and validation in both agent hosts remain follow-up work.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py' -v`: all 12 packaging tests passed.
- Skill Creator's `quick_validate.py`: the new skill passed metadata and scaffold validation.
- Checked 56 local documentation links and anchors and 7 Git ignore-rule cases.
- `git diff --check`: passed.

Local TeX compilation and end-to-end agent-host generation were not run; `latexmk` and XeLaTeX are unavailable in this environment. This change adds instructions and contribution conventions without modifying the theme or LaTeX examples.